### PR TITLE
Add dependency version pinning and hash verification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ecdsa
-base58
-python-bitcoinlib==0.7.0
+ecdsa==0.13 --hash=sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c
+base58==0.2.5 --hash=sha256:b1c481f2b8cfbc31f77dafc0e9690d92f7c03dc01481a4512eb1914e91744856
+python-bitcoinlib==0.7.0 --hash=sha256:a083f61b30c7d748f8c785591fbdc26dbad98b64946cd1fbbf25c860b8ff7c3c


### PR DESCRIPTION
From https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode:

> Since version 8.0, pip can check downloaded package archives against local hashes to protect against remote tampering.

Since btcpy is likely to be used in wallets and handle real money, it is imperative that it use dependency version pinning and hash verification to protect against the possibility of the pypi repository (or package maintainers) being compromised.

Hashes can be determined manually by downloading their respective wheel packages from pypi and running them through `sha256sum`, or using the procedure described [here](https://pip.pypa.io/en/stable/reference/pip_hash/).

Once hashes are specified, pip will refuse to install any dependency whose sha256 hash doesn't match the one specified in the requirements file.