### PR TITLE
Better Python 3.4 compatibility

### DIFF
--- a/btcpy/lib/parsing.py
+++ b/btcpy/lib/parsing.py
@@ -210,9 +210,9 @@ class TransactionParser(Parser):
         if segwit:
             witness = self._witness()
             # print('witness: {}'.format([item.hexlify() for w in witness for item in w]))
-            txins = [CoinBaseTxIn(*txin_data[2:], Witness(wit))
+            txins = [CoinBaseTxIn(*txin_data[2:], witness=Witness(wit))
                      if isinstance(txin_data[2], CoinBaseScriptSig)
-                     else TxIn(*txin_data, Witness(wit))
+                     else TxIn(*txin_data, witness=Witness(wit))
                      for txin_data, wit in zip(txins_data, witness)]
         else:
             txins = [CoinBaseTxIn(*txin_data[2:])

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -267,7 +267,7 @@ class TestStackData(unittest.TestCase):
 
     def test_failure(self):
         for size in self.fail_sizes:
-            with patch('btcpy.structs.script.len', return_value=size):
+            with patch('btcpy.structs.script.len', return_value=size, create=True):
                 with self.assertRaises(WrongPushDataOp):
                     StackData(bytearray([0]))
 


### PR DESCRIPTION
It appears that without these changes the library isn't fully Python 3.4 compatible (insofar as running `unit.py` can determine that). Similar to #11.