### PR TITLE
allow ypub and yprv keys (generated by trezor)

### DIFF
--- a/btcpy/structs/hd.py
+++ b/btcpy/structs/hd.py
@@ -36,7 +36,7 @@ class ExtendedKey(HexSerializable, metaclass=ABCMeta):
     
     @classmethod
     def decode(cls, string, check_network=True):
-        if string[0] == 'x':
+        if string[0] == 'x' or string[0] == 'y':
             mainnet = True
         elif string[0] == 't':
             mainnet = False


### PR DESCRIPTION
Trezor generates ypub and yprv keys as well. Tested with addresses generated by Trezor, simply allowing the different prefix works for key derivation, no special treatment needed. These are not master public keys, but relative keys.