### PR TITLE
Move decimals to Constants, to allow easier change of the variable.

### DIFF
--- a/btcpy/constants.py
+++ b/btcpy/constants.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+
+
 class Constants(object):
 
     _lookup = {'base58.prefixes': {'1': ('p2pkh', 'mainnet'),
@@ -16,7 +19,9 @@ class Constants(object):
                'xkeys.prefixes': {'mainnet': 'x', 'testnet': 't'},
                'xpub.version': {'mainnet': b'\x04\x88\xb2\x1e', 'testnet': b'\x04\x35\x87\xcf'},
                'xprv.version': {'mainnet': b'\x04\x88\xad\xe4', 'testnet': b'\x04\x35\x83\x94'},
-               'wif.prefixes': {'mainnet': 0x80, 'testnet': 0xef}}
+               'wif.prefixes': {'mainnet': 0x80, 'testnet': 0xef},
+               'decimals': Decimal('1e8')
+               }
 
     @staticmethod
     def get(key):

--- a/btcpy/structs/transaction.py
+++ b/btcpy/structs/transaction.py
@@ -12,6 +12,7 @@
 from binascii import hexlify, unhexlify
 from decimal import Decimal
 
+from ..constants import Constants
 from .sig import Sighash
 from .script import (ScriptBuilder, P2wpkhV0Script, P2wshV0Script, P2shScript, NulldataScript, ScriptSig,
                      CoinBaseScriptSig, ScriptPubKey)
@@ -183,7 +184,7 @@ class TxOut(Immutable, HexSerializable, Jsonizable):
 
     @classmethod
     def from_json(cls, dic):
-        return cls(int(Decimal(dic['value']) * Decimal('1e8')),
+        return cls(int(Decimal(dic['value']) * Constants.get('decimals')),
                    dic['n'],
                    ScriptBuilder.identify(bytearray(unhexlify(dic['scriptPubKey']['hex']))))
 
@@ -210,7 +211,7 @@ class TxOut(Immutable, HexSerializable, Jsonizable):
         pass
 
     def to_json(self):
-        return {'value': str(Decimal(self.value) * Decimal('1e-8')),
+        return {'value': str(Decimal(self.value) * Constants.get('decimals')),
                 'n': self.n,
                 'scriptPubKey': self.script_pubkey.to_json()}
 


### PR DESCRIPTION
For example Peercoin uses Decimal('1e6'), this makes maintenance of the port easier.