### PR TITLE
Unit test for Transaction's to/from_json

### DIFF
--- a/tests/unit.py
+++ b/tests/unit.py
@@ -250,6 +250,15 @@ class TestTransaction(unittest.TestCase):
             self.assertEqual(str(parsed_script), value['asm'])
             self.assertEqual(parsed_script.type, value['type'])
 
+    # Fails on the last transaction for some reason :\
+    def test_json(self):
+        "Check that we can convert to json and back again."
+        for data in transactions:
+            tx = Transaction.unhexlify(data["raw"])
+            tx_json = tx.to_json()
+            tx_from_json = Transaction.from_json(tx_json)
+            self.assertEqual(tx, tx_from_json)
+
 
 class TestSegWitAddress(unittest.TestCase):
 


### PR DESCRIPTION
Hello Chainside and @peerchemist :wave: 

I was working on a downstream branch ( https://github.com/PeerAssets/btcpy ) and wrote a test for the Transaction's `to_json` and `from_json` methods and noticed that the last test transaction (a SegWit transaction) fails :(

`python -m unittest tests.unit.TestTransaction` is the quickest way I could find to run it if you're curious.

I'll try to figure out how to get the test to pass eventually but I think `from_json` doesn't notice that the incoming transaction json is for a segwit transaction and drops that information.