### PR TITLE
added attribute check in SegWitTransaction's __getattr__

### DIFF
--- a/btcpy/structs/transaction.py
+++ b/btcpy/structs/transaction.py
@@ -741,7 +741,11 @@ class SegWitTransaction(BaseTransaction, Immutable):
         object.__setattr__(self, 'transaction', Transaction(version, ins, outs, locktime, txid))
 
     def __getattr__(self, item):
-        return getattr(self.transaction, item)
+        if 'transaction' not in vars(self):
+            raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, 
+                                                                            item))
+        else:
+            return getattr(self.transaction, item)
 
     @cached
     def serialize(self):


### PR DESCRIPTION
This allows SegWitTransaction to be pickled successfully. Before, when deserializing a SegWitTransaction object, pickle would throw a RecursionError as it would attempt to call getattr before self.transaction existed, which would cause it to infinitely recall getattr when it couldn't resolve self.transaction.