### PR TITLE
README example from_wif()

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ privk = PrivateKey.unhexlify(privk_hex)
 ```
 `PrivateKey` can also be extracted from a Wallet Import Format by doing:
 ```python
->>> privk = PrivateKey.form_wif(wif_key)
+>>> privk = PrivateKey.from_wif(wif_key)
 ```
 
 All these structures can be converted back to hex by using their `hexlify()` method.


### PR DESCRIPTION
Correction to example in README for private key from wif `form_wif()` to `from_wif()`