### PR TITLE
PrivateKey generation from entropy

### DIFF
--- a/btcpy/structs/crypto.py
+++ b/btcpy/structs/crypto.py
@@ -9,6 +9,7 @@
 # propagated, or distributed except according to the terms contained in the
 # LICENSE.md file.
 
+import secrets
 from binascii import unhexlify
 from ..lib.base58 import b58decode_check, b58encode_check
 from hashlib import sha256
@@ -60,6 +61,17 @@ class PrivateKey(Key):
     @staticmethod
     def unhexlify(hexa):
         return PrivateKey(bytearray(unhexlify(hexa)))
+
+    @staticmethod
+    def generate(nbytes=32):
+        """
+        Generate  a random text string, in hexadecimal with nbytes random bytes. Its length is thus 2 * nbytes.
+        Args:
+            nbytes(int): number of random bytes in the random hexadecimal string generated.
+        Returns:
+            A random hexadecimal string of length 2 * nbytes.
+        """
+        return secrets.token_hex(nbytes)
 
     def __init__(self, priv, public_compressed=True):
         self.key = priv

--- a/btcpy/structs/crypto.py
+++ b/btcpy/structs/crypto.py
@@ -65,11 +65,7 @@ class PrivateKey(Key):
     @staticmethod
     def generate():
         """
-        Generate  a random text string, in hexadecimal with nbytes random bytes. Its length is thus 2 * nbytes.
-        Args:
-            nbytes(int): number of random bytes in the random hexadecimal string generated.
-        Returns:
-            A random hexadecimal string of length 2 * nbytes.
+        Generate a random text string, in hexadecimal with 32 random bytes.
         """
         return PrivateKey(bytearray(secrets.token_hex(nbytes=32), encoding='ascii'))
 

--- a/btcpy/structs/crypto.py
+++ b/btcpy/structs/crypto.py
@@ -63,7 +63,7 @@ class PrivateKey(Key):
         return PrivateKey(bytearray(unhexlify(hexa)))
 
     @staticmethod
-    def generate(nbytes=32):
+    def generate():
         """
         Generate  a random text string, in hexadecimal with nbytes random bytes. Its length is thus 2 * nbytes.
         Args:
@@ -71,7 +71,7 @@ class PrivateKey(Key):
         Returns:
             A random hexadecimal string of length 2 * nbytes.
         """
-        return secrets.token_hex(nbytes)
+        return PrivateKey(bytearray(secrets.token_hex(nbytes=32), encoding='ascii'))
 
     def __init__(self, priv, public_compressed=True):
         self.key = priv

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -418,6 +418,10 @@ class TestKeys(unittest.TestCase):
                 priv.public_compressed = False
             self.assertEqual(priv.to_wif(w['mainnet']), w['wif'])
 
+    def test_private_key_generation(self):
+        key = PrivateKey.generate(32)
+        self.assertEqual(len(key), 64)
+
 
 class TestPubkey(unittest.TestCase):
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -419,8 +419,10 @@ class TestKeys(unittest.TestCase):
             self.assertEqual(priv.to_wif(w['mainnet']), w['wif'])
 
     def test_private_key_generation(self):
-        key = PrivateKey.generate(32)
-        self.assertEqual(len(key), 64)
+        with patch('secrets.token_hex', return_value='1697da9ed39e670abb6981dcfe9ea96db2f06e7d6d18db2474ffb2ffadd1e3bb'):
+            priv = PrivateKey.generate()
+            self.assertEqual(len(priv.key), 64)
+            self.assertEqual(priv.key, bytearray(b'1697da9ed39e670abb6981dcfe9ea96db2f06e7d6d18db2474ffb2ffadd1e3bb'))
 
 
 class TestPubkey(unittest.TestCase):


### PR DESCRIPTION
Created a @staticmethod in the `PrivateKey` class called generate that creates a PrivateKey, which is a random hexadecimal string with `nbytes` bytes, using python's secrets standard module. A corresponding unit test is added.

Please let me know if the pull request meets the requirement, or there are any suggested changes.

Thank you!

#31 